### PR TITLE
Add Tutorial Reward System

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ A decentralized platform for sharing and collaborating on DIY craft tutorials. C
 
 ## Recent Updates
 
+- Added tutorial reward claiming system for popular content
 - Added time-limited collaborative sessions with automatic expiration
 - Enhanced session validation checks
 - Improved error handling for session management
+
+## Tutorial Rewards
+
+Creators can now claim reputation token rewards when their tutorials reach certain milestones:
+- Tutorials with 10+ votes qualify for a reward of 25 reputation tokens
+- Rewards can only be claimed once per tutorial
+- Only the original creator can claim rewards


### PR DESCRIPTION
This PR introduces a new tutorial reward system that incentivizes high-quality content creation on the CraftNest platform.

Changes:
- Added new `claim-tutorial-reward` function that allows tutorial creators to claim reputation tokens
- Added reward qualification threshold of 10 votes
- Implemented one-time claiming with validation
- Added new error constant for duplicate claim attempts
- Added comprehensive tests for the reward claiming functionality
- Updated documentation to reflect the new reward system

Security considerations:
- Only the original creator can claim rewards
- Rewards can only be claimed once per tutorial
- Vote threshold prevents gaming the system

The enhancement provides additional motivation for creators to produce quality content while maintaining the platform's integrity through appropriate validation checks.